### PR TITLE
Added support for 2nd central heating circuit

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ sensor:
       name: "boiler 2 temperature"
     return_temperature:
       name: "return temperature"
+    outside_temperature:
+      name: "outside temperature"
     oem_error_code:
       name: "OEM error code"
     oem_diagnostic_code:

--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ sensor:
       name: "boiler 2 temperature"
     return_temperature:
       name: "return temperature"
+    oem_error_code:
+      name: "OEM error code"
+    oem_diagnostic_code:
+      name: "OEM diagnostic code"
 
 binary_sensor:
   - platform: opentherm
@@ -78,6 +82,18 @@ binary_sensor:
       name: "fault"
     diagnostic:
       name: "diagnostic"
+    service_request:
+      name: "service request"
+    lockout_reset:
+      name: "lockout reset"
+    water_pressure_fault:
+      name: "water pressure fault"
+    gas_flame_fault:
+      name: "gas/flame fault"
+    air_pressure_fault:
+      name: "air pressure fault"
+    water_over_temperature_fault:
+      name: "water over temperature fault"
 
 switch:
   - platform: opentherm

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ sensor:
       name: "DHW temperature"
     boiler_temperature:
       name: "boiler temperature"
+    boiler_2_temperature:
+      name: "boiler 2 temperature"
     return_temperature:
       name: "return temperature"
 
@@ -66,6 +68,8 @@ binary_sensor:
   - platform: opentherm
     ch_active:
       name: "CH active"
+    ch_2_active:
+      name: "CH 2 active"
     dhw_active:
       name: "DHW active"
     flame_active:
@@ -79,6 +83,8 @@ switch:
   - platform: opentherm
     ch_enabled:
       name: "CH enabled"
+    ch_2_enabled:
+      name: "CH 2 enabled"
     dhw_enabled:
       name: "DHW enabled"
 
@@ -86,6 +92,12 @@ number:
   - platform: opentherm
     ch_setpoint_temperature:
       name: "CH setpoint temperature"
+      min_value: 20.0
+      max_value: 45.0
+      step: 0.5
+      restore_value: true
+    ch_2_setpoint_temperature:
+      name: "CH 2 setpoint temperature"
       min_value: 20.0
       max_value: 45.0
       step: 0.5

--- a/components/opentherm/binary_sensor.py
+++ b/components/opentherm/binary_sensor.py
@@ -9,6 +9,7 @@ from esphome.const import (
 from . import OpenThermComponent, CONF_OPENTHERM_ID
 
 CONF_CH_ACTIVE = "ch_active"
+CONF_CH_2_ACTIVE = "ch_2_active"
 CONF_DHW_ACTIVE = "dhw_active"
 CONF_FLAME_ACTIVE = "flame_active"
 CONF_COOLING_ACTIVE = "cooling_active"
@@ -17,6 +18,7 @@ CONF_DIAGNOSTIC = "diagnostic"
 
 TYPES = [
     CONF_CH_ACTIVE,
+    CONF_CH_2_ACTIVE,
     CONF_DHW_ACTIVE,
     CONF_COOLING_ACTIVE,
     CONF_FLAME_ACTIVE,
@@ -29,6 +31,9 @@ CONFIG_SCHEMA = cv.All(
         {
             cv.GenerateID(CONF_OPENTHERM_ID): cv.use_id(OpenThermComponent),
             cv.Optional(CONF_CH_ACTIVE): binary_sensor.binary_sensor_schema(
+                device_class=DEVICE_CLASS_HEAT,
+            ),
+            cv.Optional(CONF_CH_2_ACTIVE): binary_sensor.binary_sensor_schema(
                 device_class=DEVICE_CLASS_HEAT,
             ),
             cv.Optional(CONF_DHW_ACTIVE): binary_sensor.binary_sensor_schema(

--- a/components/opentherm/binary_sensor.py
+++ b/components/opentherm/binary_sensor.py
@@ -15,6 +15,12 @@ CONF_FLAME_ACTIVE = "flame_active"
 CONF_COOLING_ACTIVE = "cooling_active"
 CONF_FAULT = "fault"
 CONF_DIAGNOSTIC = "diagnostic"
+CONF_SERVICE_REQUEST = "service_request"
+CONF_LOCKOUT_RESET = "lockout_reset"
+CONF_WATER_PRESSURE_FAULT = "water_pressure_fault"
+CONF_GAS_FLAME_FAULT = "gas_flame_fault"
+CONF_AIR_PRESSURE_FAULT = "air_pressure_fault"
+CONF_WATER_OVER_TEMPERATURE_FAULT = "water_over_temperature_fault"
 
 TYPES = [
     CONF_CH_ACTIVE,
@@ -24,6 +30,12 @@ TYPES = [
     CONF_FLAME_ACTIVE,
     CONF_FAULT,
     CONF_DIAGNOSTIC,
+    CONF_SERVICE_REQUEST,
+    CONF_LOCKOUT_RESET,
+    CONF_WATER_PRESSURE_FAULT,
+    CONF_GAS_FLAME_FAULT,
+    CONF_AIR_PRESSURE_FAULT,
+    CONF_WATER_OVER_TEMPERATURE_FAULT
 ]
 
 CONFIG_SCHEMA = cv.All(
@@ -49,6 +61,24 @@ CONFIG_SCHEMA = cv.All(
                 device_class=DEVICE_CLASS_PROBLEM,
             ),
             cv.Optional(CONF_DIAGNOSTIC): binary_sensor.binary_sensor_schema(
+                device_class=DEVICE_CLASS_PROBLEM,
+            ),
+            cv.Optional(CONF_SERVICE_REQUEST): binary_sensor.binary_sensor_schema(
+                device_class=DEVICE_CLASS_PROBLEM,
+            ),
+            cv.Optional(CONF_LOCKOUT_RESET): binary_sensor.binary_sensor_schema(
+                device_class=DEVICE_CLASS_PROBLEM,
+            ),
+            cv.Optional(CONF_WATER_PRESSURE_FAULT): binary_sensor.binary_sensor_schema(
+                device_class=DEVICE_CLASS_PROBLEM,
+            ),
+            cv.Optional(CONF_GAS_FLAME_FAULT): binary_sensor.binary_sensor_schema(
+                device_class=DEVICE_CLASS_PROBLEM,
+            ),
+            cv.Optional(CONF_AIR_PRESSURE_FAULT): binary_sensor.binary_sensor_schema(
+                device_class=DEVICE_CLASS_PROBLEM,
+            ),
+            cv.Optional(CONF_WATER_OVER_TEMPERATURE_FAULT): binary_sensor.binary_sensor_schema(
                 device_class=DEVICE_CLASS_PROBLEM,
             ),
         }

--- a/components/opentherm/number/__init__.py
+++ b/components/opentherm/number/__init__.py
@@ -21,6 +21,7 @@ from .. import opentherm
 CustomNumber = opentherm.class_("CustomNumber", number.Number, cg.Component)
 
 CONF_CH_SETPOINT_TEMPERATURE = "ch_setpoint_temperature"
+CONF_CH_2_SETPOINT_TEMPERATURE = "ch_2_setpoint_temperature"
 CONF_DHW_SETPOINT_TEMPERATURE = "dhw_setpoint_temperature"
 
 ICON_HOME_THERMOMETER = "mdi:home-thermometer"
@@ -28,6 +29,7 @@ ICON_WATER_THERMOMETER = "mdi:water-thermometer"
 
 TYPES = [
     CONF_CH_SETPOINT_TEMPERATURE,
+    CONF_CH_2_SETPOINT_TEMPERATURE,
     CONF_DHW_SETPOINT_TEMPERATURE,
 ]
 
@@ -36,6 +38,23 @@ CONFIG_SCHEMA = cv.All(
         {
             cv.GenerateID(CONF_OPENTHERM_ID): cv.use_id(OpenThermComponent),
             cv.Optional(CONF_CH_SETPOINT_TEMPERATURE): number.NUMBER_SCHEMA.extend(
+                {
+                    cv.GenerateID(): cv.declare_id(CustomNumber),
+                    cv.Required(CONF_MAX_VALUE): cv.float_,
+                    cv.Required(CONF_MIN_VALUE): cv.float_,
+                    cv.Required(CONF_STEP): cv.positive_float,
+                    cv.Optional(
+                        CONF_UNIT_OF_MEASUREMENT, default=UNIT_CELSIUS
+                    ): cv.string_strict,
+                    cv.Optional(CONF_ICON, default=ICON_HOME_THERMOMETER): cv.icon,
+                    cv.Optional(CONF_MODE, default="BOX"): cv.enum(
+                        number.NUMBER_MODES, upper=True
+                    ),
+                    cv.Optional(CONF_INITIAL_VALUE): cv.float_,
+                    cv.Optional(CONF_RESTORE_VALUE): cv.boolean,
+                }
+            ).extend(cv.COMPONENT_SCHEMA),
+            cv.Optional(CONF_CH_2_SETPOINT_TEMPERATURE): number.NUMBER_SCHEMA.extend(
                 {
                     cv.GenerateID(): cv.declare_id(CustomNumber),
                     cv.Required(CONF_MAX_VALUE): cv.float_,

--- a/components/opentherm/opentherm.cpp
+++ b/components/opentherm/opentherm.cpp
@@ -551,7 +551,7 @@ void OpenThermComponent::set_boiler_status_() {
 }
 
 void OpenThermComponent::enqueue_request_(uint32_t request) {
-  if (this->buffer_.size() > 20) {
+  if (this->buffer_.size() > 25) {
     this->log_message_(2, "Queue full. Discarded request", request);
   } else {
     this->buffer_.push(request);

--- a/components/opentherm/opentherm.cpp
+++ b/components/opentherm/opentherm.cpp
@@ -140,6 +140,9 @@ void OpenThermComponent::update() {
   if (this->dhw_temperature_sensor_) {
     this->request_(OpenThermMessageType::READ_DATA, OpenThermMessageID::DHW_TEMP, 0);
   }
+  if (this->outside_temperature_sensor_) {
+    this->request_(OpenThermMessageType::READ_DATA, OpenThermMessageID::OUTSIDE_TEMP, 0);
+  }
   if (this->dhw_max_temperature_sensor_ || this->dhw_min_temperature_sensor_) {
     this->request_(OpenThermMessageType::READ_DATA, OpenThermMessageID::DHW_TEMP_MAX_MIN, 0);
   }
@@ -189,6 +192,7 @@ void OpenThermComponent::dump_config() {
   LOG_SENSOR("  ", "Boiler temperature:", this->boiler_temperature_sensor_);
   LOG_SENSOR("  ", "Boiler 2 temperature:", this->boiler_2_temperature_sensor_);
   LOG_SENSOR("  ", "Return temperature:", this->return_temperature_sensor_);
+  LOG_SENSOR("  ", "Outside temperature:", this->outside_temperature_sensor_);
   LOG_SENSOR("  ", "OEM error code:", this->oem_error_code_sensor_);
   LOG_SENSOR("  ", "OEM diagnostic code:", this->oem_diagnostic_code_sensor_);
 #endif
@@ -468,6 +472,9 @@ void OpenThermComponent::process_response_(uint32_t response, OpenThermResponseS
         break;
       case OpenThermMessageID::BOILER_WATER_TEMP_2:
         this->publish_sensor_state_(this->boiler_2_temperature_sensor_, this->get_float_(response));
+        break;
+      case OpenThermMessageID::OUTSIDE_TEMP:
+        this->publish_sensor_state_(this->outside_temperature_sensor_, this->get_float_(response));
         break;
       case OpenThermMessageID::DHW_FLOW_RATE:
         this->publish_sensor_state_(this->dhw_flow_rate_sensor_, this->get_float_(response));

--- a/components/opentherm/opentherm.h
+++ b/components/opentherm/opentherm.h
@@ -38,6 +38,7 @@ class OpenThermComponent : public PollingComponent {
   sensor::Sensor *boiler_temperature_sensor_{nullptr};
   sensor::Sensor *boiler_2_temperature_sensor_{nullptr};
   sensor::Sensor *return_temperature_sensor_{nullptr};
+  sensor::Sensor *outside_temperature_sensor_{nullptr};
   sensor::Sensor *oem_error_code_sensor_{nullptr};
   sensor::Sensor *oem_diagnostic_code_sensor_{nullptr};
 #endif
@@ -89,6 +90,7 @@ class OpenThermComponent : public PollingComponent {
   void set_boiler_temperature_sensor(sensor::Sensor *sensor) { boiler_temperature_sensor_ = sensor; }
   void set_boiler_2_temperature_sensor(sensor::Sensor *sensor) { boiler_2_temperature_sensor_ = sensor; }
   void set_return_temperature_sensor(sensor::Sensor *sensor) { return_temperature_sensor_ = sensor; }
+  void set_outside_temperature_sensor(sensor::Sensor *sensor) { outside_temperature_sensor_ = sensor; }
   void set_oem_error_code_sensor(sensor::Sensor *sensor) { oem_error_code_sensor_ = sensor; }
   void set_oem_diagnostic_code_sensor(sensor::Sensor *sensor) { oem_diagnostic_code_sensor_ = sensor; }
 #endif

--- a/components/opentherm/opentherm.h
+++ b/components/opentherm/opentherm.h
@@ -36,10 +36,12 @@ class OpenThermComponent : public PollingComponent {
   sensor::Sensor *modulation_sensor_{nullptr};
   sensor::Sensor *dhw_temperature_sensor_{nullptr};
   sensor::Sensor *boiler_temperature_sensor_{nullptr};
+  sensor::Sensor *boiler_2_temperature_sensor_{nullptr};
   sensor::Sensor *return_temperature_sensor_{nullptr};
 #endif
 #ifdef USE_BINARY_SENSOR
   binary_sensor::BinarySensor *ch_active_binary_sensor_{nullptr};
+  binary_sensor::BinarySensor *ch_2_active_binary_sensor_{nullptr};
   binary_sensor::BinarySensor *dhw_active_binary_sensor_{nullptr};
   binary_sensor::BinarySensor *cooling_active_binary_sensor_{nullptr};
   binary_sensor::BinarySensor *flame_active_binary_sensor_{nullptr};
@@ -48,11 +50,13 @@ class OpenThermComponent : public PollingComponent {
 #endif
 #ifdef USE_SWITCH
   opentherm::CustomSwitch *ch_enabled_switch_{nullptr};
+  opentherm::CustomSwitch *ch_2_enabled_switch_{nullptr};
   opentherm::CustomSwitch *dhw_enabled_switch_{nullptr};
   opentherm::CustomSwitch *cooling_enabled_switch_{nullptr};
 #endif
 #ifdef USE_NUMBER
   opentherm::CustomNumber *ch_setpoint_temperature_number_{nullptr};
+  opentherm::CustomNumber *ch_2_setpoint_temperature_number_{nullptr};
   opentherm::CustomNumber *dhw_setpoint_temperature_number_{nullptr};
 #endif
 
@@ -75,10 +79,12 @@ class OpenThermComponent : public PollingComponent {
   void set_modulation_sensor(sensor::Sensor *sensor) { modulation_sensor_ = sensor; }
   void set_dhw_temperature_sensor(sensor::Sensor *sensor) { dhw_temperature_sensor_ = sensor; }
   void set_boiler_temperature_sensor(sensor::Sensor *sensor) { boiler_temperature_sensor_ = sensor; }
+  void set_boiler_2_temperature_sensor(sensor::Sensor *sensor) { boiler_2_temperature_sensor_ = sensor; }
   void set_return_temperature_sensor(sensor::Sensor *sensor) { return_temperature_sensor_ = sensor; }
 #endif
 #ifdef USE_BINARY_SENSOR
   void set_ch_active_binary_sensor(binary_sensor::BinarySensor *sensor) { ch_active_binary_sensor_ = sensor; }
+  void set_ch_2_active_binary_sensor(binary_sensor::BinarySensor *sensor) { ch_2_active_binary_sensor_ = sensor; }
   void set_dhw_active_binary_sensor(binary_sensor::BinarySensor *sensor) { dhw_active_binary_sensor_ = sensor; }
   void set_cooling_active_binary_sensor(binary_sensor::BinarySensor *sensor) { cooling_active_binary_sensor_ = sensor; }
   void set_flame_active_binary_sensor(binary_sensor::BinarySensor *sensor) { flame_active_binary_sensor_ = sensor; }
@@ -87,11 +93,13 @@ class OpenThermComponent : public PollingComponent {
 #endif
 #ifdef USE_SWITCH
   void set_ch_enabled_switch(opentherm::CustomSwitch *custom_switch) { ch_enabled_switch_ = custom_switch; }
+  void set_ch_2_enabled_switch(opentherm::CustomSwitch *custom_switch) { ch_2_enabled_switch_ = custom_switch; }
   void set_dhw_enabled_switch(opentherm::CustomSwitch *custom_switch) { dhw_enabled_switch_ = custom_switch; }
   void set_cooling_enabled_switch(opentherm::CustomSwitch *custom_switch) { cooling_enabled_switch_ = custom_switch; }
 #endif
 #ifdef USE_NUMBER
   void set_ch_setpoint_temperature_number(opentherm::CustomNumber *number) { ch_setpoint_temperature_number_ = number; }
+  void set_ch_2_setpoint_temperature_number(opentherm::CustomNumber *number) { ch_2_setpoint_temperature_number_ = number; }
   void set_dhw_setpoint_temperature_number(opentherm::CustomNumber *number) {
     dhw_setpoint_temperature_number_ = number;
   }
@@ -106,6 +114,7 @@ class OpenThermComponent : public PollingComponent {
   float confirmed_dhw_setpoint_ = 0;
   uint32_t last_millis_ = 0;
   bool wanted_ch_enabled_ = false;
+  bool wanted_ch_2_enabled_ = false;
   bool wanted_dhw_enabled_ = false;
   bool wanted_cooling_enabled_ = false;
   volatile uint32_t response_ = 0;
@@ -146,6 +155,7 @@ class OpenThermComponent : public PollingComponent {
   bool is_valid_response_(uint32_t response);
   bool is_fault_(uint32_t response) { return response & 0x1; }
   bool is_central_heating_active_(uint32_t response) { return response & 0x2; }
+  bool is_central_heating_2_active_(uint32_t response) { return response & 0x20; }
   bool is_hot_water_active_(uint32_t response) { return response & 0x4; }
   bool is_flame_on_(uint32_t response) { return response & 0x8; }
   bool is_cooling_active_(uint32_t response) { return response & 0x10; }

--- a/components/opentherm/opentherm.h
+++ b/components/opentherm/opentherm.h
@@ -38,6 +38,8 @@ class OpenThermComponent : public PollingComponent {
   sensor::Sensor *boiler_temperature_sensor_{nullptr};
   sensor::Sensor *boiler_2_temperature_sensor_{nullptr};
   sensor::Sensor *return_temperature_sensor_{nullptr};
+  sensor::Sensor *oem_error_code_sensor_{nullptr};
+  sensor::Sensor *oem_diagnostic_code_sensor_{nullptr};
 #endif
 #ifdef USE_BINARY_SENSOR
   binary_sensor::BinarySensor *ch_active_binary_sensor_{nullptr};
@@ -47,6 +49,12 @@ class OpenThermComponent : public PollingComponent {
   binary_sensor::BinarySensor *flame_active_binary_sensor_{nullptr};
   binary_sensor::BinarySensor *fault_binary_sensor_{nullptr};
   binary_sensor::BinarySensor *diagnostic_binary_sensor_{nullptr};
+  binary_sensor::BinarySensor *service_request_binary_sensor_{nullptr};
+  binary_sensor::BinarySensor *lockout_reset_binary_sensor_{nullptr};
+  binary_sensor::BinarySensor *water_pressure_fault_binary_sensor_{nullptr};
+  binary_sensor::BinarySensor *gas_flame_fault_binary_sensor_{nullptr};
+  binary_sensor::BinarySensor *air_pressure_fault_binary_sensor_{nullptr};
+  binary_sensor::BinarySensor *water_over_temperature_fault_binary_sensor_{nullptr};
 #endif
 #ifdef USE_SWITCH
   opentherm::CustomSwitch *ch_enabled_switch_{nullptr};
@@ -81,6 +89,8 @@ class OpenThermComponent : public PollingComponent {
   void set_boiler_temperature_sensor(sensor::Sensor *sensor) { boiler_temperature_sensor_ = sensor; }
   void set_boiler_2_temperature_sensor(sensor::Sensor *sensor) { boiler_2_temperature_sensor_ = sensor; }
   void set_return_temperature_sensor(sensor::Sensor *sensor) { return_temperature_sensor_ = sensor; }
+  void set_oem_error_code_sensor(sensor::Sensor *sensor) { oem_error_code_sensor_ = sensor; }
+  void set_oem_diagnostic_code_sensor(sensor::Sensor *sensor) { oem_diagnostic_code_sensor_ = sensor; }
 #endif
 #ifdef USE_BINARY_SENSOR
   void set_ch_active_binary_sensor(binary_sensor::BinarySensor *sensor) { ch_active_binary_sensor_ = sensor; }
@@ -90,6 +100,24 @@ class OpenThermComponent : public PollingComponent {
   void set_flame_active_binary_sensor(binary_sensor::BinarySensor *sensor) { flame_active_binary_sensor_ = sensor; }
   void set_fault_binary_sensor(binary_sensor::BinarySensor *sensor) { fault_binary_sensor_ = sensor; }
   void set_diagnostic_binary_sensor(binary_sensor::BinarySensor *sensor) { diagnostic_binary_sensor_ = sensor; }
+  void set_service_request_binary_sensor(binary_sensor::BinarySensor *sensor) {
+    service_request_binary_sensor_ = sensor;
+  }
+  void set_lockout_reset_binary_sensor(binary_sensor::BinarySensor *sensor) {
+    lockout_reset_binary_sensor_ = sensor;
+  }
+  void set_water_pressure_fault_binary_sensor(binary_sensor::BinarySensor *sensor) {
+    water_pressure_fault_binary_sensor_ = sensor;
+  }
+  void set_gas_flame_fault_binary_sensor(binary_sensor::BinarySensor *sensor) {
+    gas_flame_fault_binary_sensor_ = sensor;
+  }
+  void set_air_pressure_fault_binary_sensor(binary_sensor::BinarySensor *sensor) {
+    air_pressure_fault_binary_sensor_ = sensor;
+  }
+  void set_water_over_temperature_fault_binary_sensor(binary_sensor::BinarySensor *sensor) {
+    water_over_temperature_fault_binary_sensor_ = sensor;
+  }
 #endif
 #ifdef USE_SWITCH
   void set_ch_enabled_switch(opentherm::CustomSwitch *custom_switch) { ch_enabled_switch_ = custom_switch; }
@@ -99,7 +127,9 @@ class OpenThermComponent : public PollingComponent {
 #endif
 #ifdef USE_NUMBER
   void set_ch_setpoint_temperature_number(opentherm::CustomNumber *number) { ch_setpoint_temperature_number_ = number; }
-  void set_ch_2_setpoint_temperature_number(opentherm::CustomNumber *number) { ch_2_setpoint_temperature_number_ = number; }
+  void set_ch_2_setpoint_temperature_number(opentherm::CustomNumber *number) {
+    ch_2_setpoint_temperature_number_ = number;
+  }
   void set_dhw_setpoint_temperature_number(opentherm::CustomNumber *number) {
     dhw_setpoint_temperature_number_ = number;
   }
@@ -153,13 +183,6 @@ class OpenThermComponent : public PollingComponent {
   void send_bit_(bool high);
 
   bool is_valid_response_(uint32_t response);
-  bool is_fault_(uint32_t response) { return response & 0x1; }
-  bool is_central_heating_active_(uint32_t response) { return response & 0x2; }
-  bool is_central_heating_2_active_(uint32_t response) { return response & 0x20; }
-  bool is_hot_water_active_(uint32_t response) { return response & 0x4; }
-  bool is_flame_on_(uint32_t response) { return response & 0x8; }
-  bool is_cooling_active_(uint32_t response) { return response & 0x10; }
-  bool is_diagnostic_(uint32_t response) { return response & 0x40; }
   uint16_t get_uint16_(const uint32_t response) const {
     const uint16_t u88 = response & 0xffff;
     return u88;

--- a/components/opentherm/sensor.py
+++ b/components/opentherm/sensor.py
@@ -26,6 +26,7 @@ CONF_DHW_TEMPERATURE = "dhw_temperature"
 CONF_BOILER_TEMPERATURE = "boiler_temperature"
 CONF_BOILER_2_TEMPERATURE = "boiler_2_temperature"
 CONF_RETURN_TEMPERATURE = "return_temperature"
+CONF_OUTSIDE_TEMPERATURE = "outside_temperature"
 CONF_OEM_ERROR_CODE = "oem_error_code"
 CONF_OEM_DIAGNOSTIC_CODE = "oem_diagnostic_code"
 
@@ -47,6 +48,7 @@ TYPES = [
     CONF_BOILER_TEMPERATURE,
     CONF_BOILER_2_TEMPERATURE,
     CONF_RETURN_TEMPERATURE,
+    CONF_OUTSIDE_TEMPERATURE,
     CONF_OEM_ERROR_CODE,
     CONF_OEM_DIAGNOSTIC_CODE
 ]
@@ -120,6 +122,13 @@ CONFIG_SCHEMA = cv.All(
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
             cv.Optional(CONF_RETURN_TEMPERATURE): sensor.sensor_schema(
+                unit_of_measurement=UNIT_CELSIUS,
+                icon=ICON_THERMOMETER,
+                accuracy_decimals=1,
+                device_class=DEVICE_CLASS_TEMPERATURE,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_OUTSIDE_TEMPERATURE): sensor.sensor_schema(
                 unit_of_measurement=UNIT_CELSIUS,
                 icon=ICON_THERMOMETER,
                 accuracy_decimals=1,

--- a/components/opentherm/sensor.py
+++ b/components/opentherm/sensor.py
@@ -5,7 +5,6 @@ from esphome.const import (
     CONF_PRESSURE,
     DEVICE_CLASS_TEMPERATURE,
     DEVICE_CLASS_PRESSURE,
-    DEVICE_CLASS_WATER,
     ICON_GAUGE,
     ICON_THERMOMETER,
     STATE_CLASS_MEASUREMENT,
@@ -22,6 +21,7 @@ CONF_DHW_FLOW_RATE = "dhw_flow_rate"
 CONF_MODULATION = "modulation"
 CONF_DHW_TEMPERATURE = "dhw_temperature"
 CONF_BOILER_TEMPERATURE = "boiler_temperature"
+CONF_BOILER_2_TEMPERATURE = "boiler_2_temperature"
 CONF_RETURN_TEMPERATURE = "return_temperature"
 
 ICON_HOME_THERMOMETER = "mdi:home-thermometer"
@@ -40,6 +40,7 @@ TYPES = [
     CONF_MODULATION,
     CONF_DHW_TEMPERATURE,
     CONF_BOILER_TEMPERATURE,
+    CONF_BOILER_2_TEMPERATURE,
     CONF_RETURN_TEMPERATURE,
 ]
 
@@ -98,6 +99,13 @@ CONFIG_SCHEMA = cv.All(
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
             cv.Optional(CONF_BOILER_TEMPERATURE): sensor.sensor_schema(
+                unit_of_measurement=UNIT_CELSIUS,
+                icon=ICON_THERMOMETER,
+                accuracy_decimals=1,
+                device_class=DEVICE_CLASS_TEMPERATURE,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_BOILER_2_TEMPERATURE): sensor.sensor_schema(
                 unit_of_measurement=UNIT_CELSIUS,
                 icon=ICON_THERMOMETER,
                 accuracy_decimals=1,

--- a/components/opentherm/sensor.py
+++ b/components/opentherm/sensor.py
@@ -5,11 +5,14 @@ from esphome.const import (
     CONF_PRESSURE,
     DEVICE_CLASS_TEMPERATURE,
     DEVICE_CLASS_PRESSURE,
+    DEVICE_CLASS_EMPTY,
     ICON_GAUGE,
     ICON_THERMOMETER,
+    ICON_EMPTY,
     STATE_CLASS_MEASUREMENT,
     UNIT_PERCENT,
     UNIT_CELSIUS,
+    UNIT_EMPTY
 )
 from . import OpenThermComponent, CONF_OPENTHERM_ID
 
@@ -23,6 +26,8 @@ CONF_DHW_TEMPERATURE = "dhw_temperature"
 CONF_BOILER_TEMPERATURE = "boiler_temperature"
 CONF_BOILER_2_TEMPERATURE = "boiler_2_temperature"
 CONF_RETURN_TEMPERATURE = "return_temperature"
+CONF_OEM_ERROR_CODE = "oem_error_code"
+CONF_OEM_DIAGNOSTIC_CODE = "oem_diagnostic_code"
 
 ICON_HOME_THERMOMETER = "mdi:home-thermometer"
 ICON_WATER_THERMOMETER = "mdi:water-thermometer"
@@ -42,6 +47,8 @@ TYPES = [
     CONF_BOILER_TEMPERATURE,
     CONF_BOILER_2_TEMPERATURE,
     CONF_RETURN_TEMPERATURE,
+    CONF_OEM_ERROR_CODE,
+    CONF_OEM_DIAGNOSTIC_CODE
 ]
 
 CONFIG_SCHEMA = cv.All(
@@ -118,6 +125,18 @@ CONFIG_SCHEMA = cv.All(
                 accuracy_decimals=1,
                 device_class=DEVICE_CLASS_TEMPERATURE,
                 state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_OEM_ERROR_CODE): sensor.sensor_schema(
+                unit_of_measurement=UNIT_EMPTY,
+                icon=ICON_EMPTY,
+                accuracy_decimals=0,
+                device_class=DEVICE_CLASS_EMPTY,
+            ),
+            cv.Optional(CONF_OEM_DIAGNOSTIC_CODE): sensor.sensor_schema(
+                unit_of_measurement=UNIT_EMPTY,
+                icon=ICON_EMPTY,
+                accuracy_decimals=0,
+                device_class=DEVICE_CLASS_EMPTY,
             ),
         }
     ).extend(cv.COMPONENT_SCHEMA)

--- a/components/opentherm/switch/__init__.py
+++ b/components/opentherm/switch/__init__.py
@@ -13,6 +13,7 @@ from .. import opentherm
 CustomSwitch = opentherm.class_("CustomSwitch", switch.Switch, cg.Component)
 
 CONF_CH_ENABLED = "ch_enabled"
+CONF_CH_2_ENABLED = "ch_2_enabled"
 CONF_DHW_ENABLED = "dhw_enabled"
 CONF_COOLING_ENABLED = "cooling_enabled"
 
@@ -21,6 +22,7 @@ ICON_SNOWFLAKE = "mdi:snowflake"
 
 TYPES = [
     CONF_CH_ENABLED,
+    CONF_CH_2_ENABLED,
     CONF_DHW_ENABLED,
     CONF_COOLING_ENABLED,
 ]
@@ -30,6 +32,10 @@ CONFIG_SCHEMA = cv.All(
         {
             cv.GenerateID(CONF_OPENTHERM_ID): cv.use_id(OpenThermComponent),
             cv.Optional(CONF_CH_ENABLED): switch.switch_schema(
+                class_=CustomSwitch,
+                icon=ICON_RADIATOR,
+            ),
+            cv.Optional(CONF_CH_2_ENABLED): switch.switch_schema(
                 class_=CustomSwitch,
                 icon=ICON_RADIATOR,
             ),


### PR DESCRIPTION
Edit config:

```
...
external_components:
  source: github://khenderick/esphome-opentherm@feature/ch2
  components: [opentherm]
  refresh: 0s
...
sensor:
  ...
  - platform: opentherm
    ...
    boiler_2_temperature:
      name: "boiler 2 temperature"
    outside_temperature:
      name: "outside temperature"
    oem_error_code:
      name: "OEM error code"
    oem_diagnostic_code:
      name: "OEM diagnostic code"
    ...
  ...
...
binary_sensor:
  ...
  - platform: opentherm
    ...
    ch_2_active:
      name: "CH 2 active"
    service_request:
      name: "service request"
    lockout_reset:
      name: "lockout reset"
    water_pressure_fault:
      name: "water pressure fault"
    gas_flame_fault:
      name: "gas/flame fault"
    air_pressure_fault:
      name: "air pressure fault"
    water_over_temperature_fault:
      name: "water over temperature fault"
    ...
  ...
...
switch:
  ...
  - platform: opentherm
    ...
    ch_2_enabled:
      name: "CH 2 enabled"
    ...
  ...
...
number:
  ...
  - platform: opentherm
    ...
    ch_2_setpoint_temperature:
      name: "CH 2 setpoint temperature"
      min_value: 20.0
      max_value: 45.0
      step: 0.5
      restore_value: true
    ...
  ...
...
```

Note that after configuring sensors, you need to check the logs for UNKNOWN-messages as typically not all boilers support all messages. Unknown sensors should be removed from the configuration again.